### PR TITLE
Update regenbogen-ice api paths

### DIFF
--- a/regenbogen-ice-client/src/commonMain/kotlin/dev/schlaubi/hafalsch/rainbow_ice/annotations/ExperimentalRainbowICEApi.kt
+++ b/regenbogen-ice-client/src/commonMain/kotlin/dev/schlaubi/hafalsch/rainbow_ice/annotations/ExperimentalRainbowICEApi.kt
@@ -1,9 +1,0 @@
-package dev.schlaubi.hafalsch.rainbow_ice.annotations
-
-/**
- * Annotation marking experimental rainbow ice apis.
- */
-@Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION)
-@MustBeDocumented
-@RequiresOptIn
-public annotation class ExperimentalRainbowICEApi

--- a/regenbogen-ice-client/src/commonMain/kotlin/dev/schlaubi/hafalsch/rainbow_ice/routes/RainbowICE.kt
+++ b/regenbogen-ice-client/src/commonMain/kotlin/dev/schlaubi/hafalsch/rainbow_ice/routes/RainbowICE.kt
@@ -1,6 +1,5 @@
 package dev.schlaubi.hafalsch.rainbow_ice.routes
 
-import dev.schlaubi.hafalsch.rainbow_ice.annotations.ExperimentalRainbowICEApi
 import dev.schlaubi.hafalsch.rainbow_ice.entity.TrainVehicle as TrainVehicleEntity
 import io.ktor.resources.*
 import kotlinx.serialization.SerialName
@@ -66,19 +65,5 @@ public class RainbowICE {
             @SerialName("include_marudor_link") val includeMarudorLink: Boolean? = null,
             val trainVehicle: TrainVehicle = TrainVehicle()
         )
-
-
-        /**
-         * Probably retrieves all trains.
-         *
-         * **This api exists in the code, however does not exist on the production instance**
-         *
-         * https://github.com/regenbogen-ice/api/blob/canary/src/webserver/paths/train_vehicle.ts#L124-L132 exists
-         * however https://regenbogen-ice.de/api/train_vehicle/all returns 404
-         */
-        @ExperimentalRainbowICEApi
-        @Serializable
-        @Resource("all")
-        public data class All(val trainVehicle: TrainVehicle = TrainVehicle())
     }
 }

--- a/regenbogen-ice-client/src/commonMain/kotlin/dev/schlaubi/hafalsch/rainbow_ice/routes/RainbowICE.kt
+++ b/regenbogen-ice-client/src/commonMain/kotlin/dev/schlaubi/hafalsch/rainbow_ice/routes/RainbowICE.kt
@@ -33,21 +33,21 @@ public class RainbowICE {
      * **This only includes long distance travel stations**
      */
     @Serializable
-    @Resource("stationSearch/{query}")
+    @Resource("v1/station_search/{query}")
     public data class StationSearch(val query: String, val rainbowICE: RainbowICE = RainbowICE())
 
     /**
      * Provides train autocomplete for [query] (TZn and name).
      */
     @Serializable
-    @Resource("autocomplete/{query}")
+    @Resource("v1/autocomplete/{query}")
     public data class Autocomplete(val query: String, val rainbowICE: RainbowICE = RainbowICE())
 
     /**
      * Meta-class for `/train_vehicle` route.
      */
     @Serializable
-    @Resource("train_vehicle")
+    @Resource("v1/train_vehicle")
     public data class TrainVehicle(val rainbowICE: RainbowICE = RainbowICE()) {
         /**
          * Fetches [train information][TrainVehicleEntity] for [query].

--- a/regenbogen-ice-client/src/commonMain/kotlin/dev/schlaubi/hafalsch/rainbow_ice/util/Url.kt
+++ b/regenbogen-ice-client/src/commonMain/kotlin/dev/schlaubi/hafalsch/rainbow_ice/util/Url.kt
@@ -1,3 +1,3 @@
 package dev.schlaubi.hafalsch.rainbow_ice.util
 
-public const val DEFAULT_RAINBOW_ICE_URL: String = "https://www.regenbogen-ice.de/api"
+public const val DEFAULT_RAINBOW_ICE_URL: String = "https://regenbogen-ice.de/api"


### PR DESCRIPTION
1. The regenbogen-ice root api should be https://regenbogen-ice.de/api instead of https://www.regenbogen-ice.de/api
2. The new api versions doesn't support the train_vehicle all api. So I removed the api and the RegenbogenICE experimental annotation.
3. The new api has versioning so the old paths are deprecated.